### PR TITLE
Use timing-resistent Eq instance for hash comparison

### DIFF
--- a/src/Crypto/Scrypt.hs
+++ b/src/Crypto/Scrypt.hs
@@ -23,7 +23,9 @@ module Crypto.Scrypt (
 import Control.Applicative
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as B
+import Data.ByteString.Unsafe
 import Data.Maybe
+import Data.Monoid
 import Foreign (Ptr, Word8, Word32, Word64, allocaBytes, castPtr)
 import Foreign.C
 import System.Entropy (getEntropy)
@@ -34,7 +36,30 @@ newtype Pass          = Pass     { getPass :: B.ByteString } deriving (Show, Eq)
 newtype Salt          = Salt     { getSalt :: B.ByteString } deriving (Show, Eq)
 newtype PassHash      = PassHash { getHash :: B.ByteString } deriving (Show, Eq)
 newtype EncryptedPass =
-    EncryptedPass { getEncryptedPass  :: B.ByteString } deriving (Show, Eq)
+    EncryptedPass { getEncryptedPass  :: B.ByteString } deriving (Show)
+
+-- |Timing-resistant comparison for password hashes - time to compare
+--  two equal hashes and two differing hashes is identical. Slower
+--  than '(==)' on 'ByteString's by less than a microsecond on
+--  scrypt-sized hashes.
+instance Eq EncryptedPass where
+    (==) (EncryptedPass "") (EncryptedPass "") =
+        True
+    (==) (EncryptedPass a) (EncryptedPass b) =
+        (&&) (la == lb) $! (match (buffered a) (buffered b) True)
+      where
+        buffered bs = bs <> B.replicate (maxLen - (B.length bs)) '\0'
+
+        maxLen = fromIntegral $ max la lb
+
+        (la, lb) = (B.length a, B.length b)
+
+        match as bs acc
+          | B.null as || B.null bs =
+              acc
+          | otherwise                =
+              match (unsafeTail as) (unsafeTail bs)
+                  ((&&) acc $! (unsafeHead as == unsafeHead bs))
 
 ------------------------------------------------------------------------------
 -- $params


### PR DESCRIPTION
Using `ByteString`'s `Eq` instance for hash comparison makes it possible to obtain information about how many bytes in the hashes matched. This is not a big issue as long as the salt remains secret, but this change reduces the number of avenues of attack should the salt become known.

The `EncryptedPass` `Eq` instance is somewhat slower than the one in `bytestring`; on my machine the difference was less than a microsecond on scrypt-size hashes. (The benchmarks are in [this branch](https://github.com/olorin/scrypt/tree/topic/eq-benchmarks); I wasn't sure if they belonged in this PR, but if you think they're useful I'll open another PR.)

Let me know what you think. Another option I considered was exposing another function (`timingsafeVerify` or something) rather than the `Eq` instance, but the cost was low enough I figured it wasn't worth it.
