### PR TITLE
scrypt.cabal: Make it unbuildable on arches other that x86_64

### DIFF
--- a/scrypt.cabal
+++ b/scrypt.cabal
@@ -36,11 +36,19 @@ source-repository head
 library
     exposed-modules: Crypto.Scrypt
     hs-source-dirs: src
-    build-depends:
-        base == 4.*,
-        base64-bytestring >= 0.1,
-        bytestring >= 0.9,
-        entropy >= 0.2
+
+    if arch(x86_64)
+        build-depends:
+            base == 4.*,
+            base64-bytestring >= 0.1,
+            bytestring >= 0.9,
+            entropy >= 0.2
+    else
+        -- The underlying C library requires SSE and related instructions which
+        -- are only available on x86_64, so we make this unbuildable on other
+        -- arches.
+        build-depends:
+            base < 0
 
     ghc-options: -Wall
     ghc-prof-options: -auto-all


### PR DESCRIPTION
The underlying library depends on SSE and related instructions which are only available on the x86_64 arch.